### PR TITLE
fix: let Reader opened when query url include last comment item

### DIFF
--- a/resources/assets/js/page/Major/CardList/useCommentFlow.js
+++ b/resources/assets/js/page/Major/CardList/useCommentFlow.js
@@ -31,7 +31,7 @@ function useCommentFlow({ majorData }) {
 
     // Open Reader if id is sets by url when user enter the website.
     useEffect(() => {
-        if (!index && indexById && indexById > 0) {
+        if (!index && indexById >= 0) {
             let itemData = majorData[indexById];
             setModalContent(transIntoModalData(itemData, indexById));
             setIsModalOpen(true);


### PR DESCRIPTION
## Description
原本的if-cond判斷的方式會讓 findIndex找到位置0的資料時判斷為false，把這個改掉了
cc @vacantron 

## Github issue
- https://github.com/JiaAnTW/NCKU_Trans/issues/91
## Related PRs
- https://github.com/JiaAnTW/NCKU_Trans/pull/59
## Scope
- /major
## Screenshot
