### PR TITLE
fix: data haven't clear after return fail and same name didn't check 

### DIFF
--- a/app/Http/Controllers/CategoryManageController.php
+++ b/app/Http/Controllers/CategoryManageController.php
@@ -25,6 +25,12 @@ class CategoryManageController extends Controller
         $uuid = Str::uuid()->toString();
         $category->id = $uuid;
         $category->name = $request->studyType;
+        //check if there is same name in database
+        $studyType = CategoryManage::where('name', '=', $request->studyType)->first();
+        if ($studyType != null)
+        {
+            return array(["status"=>"fail", "msg"=>"Same name in database."]);
+        }
         $category->save();
 
         return array('status' => "success");
@@ -40,6 +46,12 @@ class CategoryManageController extends Controller
         catch(Exception $e){
             error_log("Error:".$e);
             return array('status' => "fail");
+        }
+        //check if there is same name in database
+        $studyType = CategoryManage::where('name', '=', $request->studyType)->first();
+        if ($studyType != null)
+        {
+            return array(["status"=>"fail", "msg"=>"Same name in database."]);
         }
         $category->name = $request->studyType;
         $category->save();

--- a/app/Http/Controllers/StatisticManageController.php
+++ b/app/Http/Controllers/StatisticManageController.php
@@ -74,7 +74,7 @@ class StatisticManageController extends Controller
         } 
         else 
         {
-            return array(["status"=>"fail"]);
+            return array(["status"=>"fail", "msg"=>"Same name in database."]);
         }
 
     }
@@ -94,7 +94,7 @@ class StatisticManageController extends Controller
         $stat = StatisticManage::where('name', '=', $request->name)->first();
         if ($stat != null)
         {
-            return array(["status"=>"fail"]);
+            return array(["status"=>"fail", "msg"=>"Same name in database."]);
         }
         $statistic->name = $request->name;
         if( strcmp($request->dataType, "string") != 0)

--- a/app/Http/Controllers/StatisticManageController.php
+++ b/app/Http/Controllers/StatisticManageController.php
@@ -90,6 +90,12 @@ class StatisticManageController extends Controller
             error_log("Error:".$e);
             return array('status' => "fail");
         }
+        //check if there is same name in database
+        $stat = StatisticManage::where('name', '=', $request->name)->first();
+        if ($stat != null)
+        {
+            return array(["status"=>"fail"]);
+        }
         $statistic->name = $request->name;
         if( strcmp($request->dataType, "string") != 0)
         {

--- a/app/Http/Controllers/StudyController.php
+++ b/app/Http/Controllers/StudyController.php
@@ -101,6 +101,7 @@ class StudyController extends Controller
                 {
                     if($stat["max"] < $element['value'] or $stat["min"] > $element['value'])
                     {
+                        $study->categories()->delete();
                         return array('status' => "fail");
                     }
                 }
@@ -112,6 +113,7 @@ class StudyController extends Controller
             }
             else
             {
+                $study->categories()->delete();
                 return array('status' => "fail");
             }
         }
@@ -138,15 +140,6 @@ class StudyController extends Controller
         $study->content = $request->content;
         $study->confirm = $request->confirm;
 
-        $study->categories()->delete();
-        foreach ( $request["category"] as $element ) {
-            $category = new Category;
-            $category->name = $element["name"];
-            $uuid = Str::uuid()->toString();
-            $category->id = $uuid;
-            $study->categories()->save($category);
-        }
-
         //update statistic
         foreach ( $request["statistic"] as $element ) {
             $stat = StatisticManage::where('name', '=', $element['name'])->first();
@@ -168,6 +161,15 @@ class StudyController extends Controller
             {
                 return array('status' => "fail");
             }
+        }
+
+        $study->categories()->delete();
+        foreach ( $request["category"] as $element ) {
+            $category = new Category;
+            $category->name = $element["name"];
+            $uuid = Str::uuid()->toString();
+            $category->id = $uuid;
+            $study->categories()->save($category);
         }
 
         $study->save();


### PR DESCRIPTION
## Description

- create and update api didn't check same name in category
- add msg if there is same name in database for statistic
- update api for statistic didn't check if there is same name
- some data didn't delete when return status fail

## Github issue
- #115 
## Related PRs

## Scope


## Screenshot
