### PR TITLE
fix: adjust padding-bottom in major scroll cardList

### DIFF
--- a/resources/assets/js/page/Major/CardList/index.js
+++ b/resources/assets/js/page/Major/CardList/index.js
@@ -20,7 +20,7 @@ function CardsList() {
     const { cardWidth, cardHeight } = useCardSize();
     const columnCount =
         parentWidth <= cardWidth ? 1 : Math.floor(parentWidth / cardWidth);
-    const rowCount = Math.ceil(majorData.length / columnCount);
+    const rowCount = Math.ceil(majorData.length / columnCount) + 2; // +2 is for padding-bottom
 
     const Card = useCard(columnCount);
 

--- a/resources/assets/js/page/Major/style.js
+++ b/resources/assets/js/page/Major/style.js
@@ -5,6 +5,7 @@ export const Main = styled.main`
     display: grid;
     grid-template-rows: 50px 160px auto;
     overflow-y: hidden;
+    overflow-x: hidden;
 
     @media (max-width: 990px) {
         grid-template-rows: 100px auto;


### PR DESCRIPTION
## Description
增加在轉輔心得列表無限捲動的預留底層空間
![image](https://user-images.githubusercontent.com/39335864/175765555-9cb5bad2-c100-4a27-9cbb-8ce2aef81bef.png)

## Github issue

## Related PRs

## Scope
- /
- /post
- /admin/*
- component
- Global layout
    - SideBar  

## Screenshot
