### PR TITLE
fix: increase bottom space of Post for mobile device

### DIFF
--- a/resources/assets/js/components/Reader/style.js
+++ b/resources/assets/js/components/Reader/style.js
@@ -15,7 +15,7 @@ export const ReaderLayout = styled.div`
     @media (max-width: 992px) {
         width: 360px;
         height: 500px;
-        height: 75vh;
+        height: 65vh;
         min-width: 95vw;
     }
 `;

--- a/resources/assets/js/components/StudyReader/style.js
+++ b/resources/assets/js/components/StudyReader/style.js
@@ -13,7 +13,7 @@ export const StudyReaderLayout = styled.div`
 
     @media (max-width: 992px) {
         width: 360px;
-        height: 85vh;
+        height: 65vh;
         min-width: 95vw;
     }
 `;

--- a/resources/assets/js/page/Post/style.js
+++ b/resources/assets/js/page/Post/style.js
@@ -3,4 +3,5 @@ import styled from 'styled-components';
 export const PostLayout = styled.div`
     display: grid;
     grid-template-rows: 130px auto;
+    padding-bottom: 25px;
 `;


### PR DESCRIPTION
## Description
修正在手機裝置下，post頁面會被瀏覽器的導覽列擋住的問題
## Github issue

## Related PRs

## Scope
- /
- /post
- /admin/*
- component
- Global layout
    - SideBar  

## Screenshot
